### PR TITLE
ProfilePage Listings View

### DIFF
--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -398,10 +398,21 @@ export function ProfilePage() {
           </Card.Content>
 
           <Card.Actions>
-            <Button mode="contained" onPress={handleEditPress}>
+            <Button 
+              mode="contained" 
+              onPress={handleEditPress}
+              buttonColor={theme.colors.primary}
+              textColor={theme.colors.text}
+              style={styles.actionButton}
+            >
               Edit Profile
             </Button>
-            <Button mode="outlined" onPress={handleSignOut}>
+            <Button 
+              mode="outlined" 
+              onPress={handleSignOut}
+              textColor={theme.colors.text}
+              style={[styles.actionButton, styles.signOutButton]}
+            >
               Sign Out
             </Button>
           </Card.Actions>
@@ -577,5 +588,11 @@ const styles = StyleSheet.create({
   },
   scrollViewContent: {
     paddingBottom: 32,
+  },
+  actionButton: {
+    marginHorizontal: 8,
+  },
+  signOutButton: {
+    borderColor: theme.colors.text,
   },
 });

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -973,7 +973,7 @@ export function ProfilePage() {
                     <ThemedText>No saved listings yet</ThemedText>
                     <Button 
                       mode="outlined" 
-                      onPress={() => {}} 
+                      onPress={() => navigation.navigate("index")} 
                       style={styles.exploreButton}
                       textColor={theme.colors.text}
                     >

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -60,7 +60,7 @@ const FavoritedListingCard = ({ item, onRemoveFavorite }) => {
           <Paragraph style={styles.listingAddress}>{item.address}</Paragraph>
           <View style={styles.listingChips}>
             <Chip 
-              icon="bed" 
+              icon={() => <MaterialCommunityIcons name="bed" size={16} color={theme.colors.text} />}
               style={styles.listingChip} 
               textStyle={[styles.chipText, { color: theme.colors.text }]}
               theme={{ colors: { surface: theme.colors.surface } }}
@@ -68,7 +68,7 @@ const FavoritedListingCard = ({ item, onRemoveFavorite }) => {
               {item.bedCount} beds
             </Chip>
             <Chip 
-              icon="shower" 
+              icon={() => <MaterialCommunityIcons name="shower" size={16} color={theme.colors.text} />}
               style={styles.listingChip} 
               textStyle={[styles.chipText, { color: theme.colors.text }]}
               theme={{ colors: { surface: theme.colors.surface } }}
@@ -439,7 +439,7 @@ export function ProfilePage() {
             onPress={() => setActiveTab('favorites')}
           >
             <MaterialCommunityIcons name="heart" size={24} color={theme.colors.text} />
-            <ThemedText style={styles.navButtonText}>Favorited Listings</ThemedText>
+            <ThemedText style={styles.navButtonText}>Saved</ThemedText>
           </TouchableOpacity>
           <TouchableOpacity 
             style={[styles.navButton, activeTab === 'myListings' && styles.activeNavButton]}
@@ -456,14 +456,14 @@ export function ProfilePage() {
             <Card style={styles.listingsCard}>
               <Card.Content>
                 <View style={styles.sectionHeader}>
-                  <ThemedText type="subtitle">Favorited Listings</ThemedText>
+                  <ThemedText type="subtitle">Saved</ThemedText>
                   <Chip style={styles.countChip} textStyle={{ color: theme.colors.text }}>
                     {favoritedListings.length}
                   </Chip>
                 </View>
                 {favoritedListings.length === 0 ? (
                   <View style={styles.emptyContainer}>
-                    <ThemedText>No favorited listings yet</ThemedText>
+                    <ThemedText>No saved listings yet</ThemedText>
                     <Button 
                       mode="outlined" 
                       onPress={() => {}} 
@@ -574,6 +574,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: 16,
+    paddingHorizontal: 8,
   },
   navButton: {
     flex: 1,
@@ -585,6 +586,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 8,
     borderRadius: 8,
     elevation: 2,
+    minWidth: 120,
   },
   activeNavButton: {
     backgroundColor: theme.colors.primaryContainer,

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -452,7 +452,7 @@ const PropertyCard = ({ property, onEdit, onDelete }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   return (
-    <Surface elevation={2} style={styles.propertyCardContainer}>
+    <Card style={styles.propertyCard}>
       <View style={styles.propertyImageWrapper}>
         {property.image_url ? (
           <Image 
@@ -556,7 +556,7 @@ const PropertyCard = ({ property, onEdit, onDelete }) => {
           </Dialog.Actions>
         </Dialog>
       </Portal>
-    </Surface>
+    </Card>
   );
 };
 
@@ -1094,10 +1094,15 @@ const styles = StyleSheet.create({
   propertiesContainer: {
     marginTop: 16,
   },
-  propertyCardContainer: {
-    marginBottom: 16,
+  propertyCard: {
+    marginVertical: 8,
     borderRadius: 12,
-    overflow: 'hidden',
+    backgroundColor: '#FFFFFF',
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
   },
   propertyImageWrapper: {
     height: 180,

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -543,19 +543,32 @@ const PropertyCard = ({ property, onEdit, onDelete }) => {
       </View>
 
       <Portal>
-        <Dialog visible={showDeleteConfirm} onDismiss={() => setShowDeleteConfirm(false)}>
-          <Dialog.Title>Delete Property</Dialog.Title>
+        <Dialog 
+          visible={showDeleteConfirm} 
+          onDismiss={() => setShowDeleteConfirm(false)}
+          style={{ backgroundColor: theme.colors.surface }}
+        >
+          <Dialog.Title style={{ color: theme.colors.text }}>Delete Property</Dialog.Title>
           <Dialog.Content>
-            <Paragraph>Are you sure you want to delete this property? This action cannot be undone.</Paragraph>
+            <Paragraph style={{ color: theme.colors.text }}>Are you sure you want to delete this property? This action cannot be undone.</Paragraph>
           </Dialog.Content>
-          <Dialog.Actions>
-            <Button onPress={() => setShowDeleteConfirm(false)}>Cancel</Button>
+          <Dialog.Actions style={{ justifyContent: 'space-around', paddingHorizontal: 16, paddingBottom: 8 }}>
+            <Button 
+              onPress={() => setShowDeleteConfirm(false)}
+              textColor={theme.colors.text}
+              style={{ minWidth: 100, borderColor: theme.colors.primary }}
+            >
+              Cancel
+            </Button>
             <Button 
               onPress={() => {
                 setShowDeleteConfirm(false);
                 onDelete(property.id);
               }}
-              textColor={theme.colors.error}
+              mode="contained"
+              buttonColor={theme.colors.primary}
+              textColor={theme.colors.text}
+              style={{ minWidth: 100 }}
             >
               Delete
             </Button>
@@ -1404,7 +1417,7 @@ const styles = StyleSheet.create({
     shadowRadius: 3.84,
   },
   dialog: {
-    backgroundColor: 'white',
+    backgroundColor: theme.colors.surface,
     borderRadius: 12,
     padding: 8,
   },

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
-import { View, StyleSheet, ScrollView, Image, Modal, TouchableOpacity, Alert } from "react-native";
+import { View, ScrollView, Alert, Text, Image, Modal, TouchableOpacity, StyleSheet } from "react-native";
 import { Card, Title, Paragraph, Button, TextInput, Surface, Chip, IconButton, Portal, Dialog } from "react-native-paper";
 import { ThemedText } from "./ThemedText";
 import { firestore } from "../config/firebase";
@@ -260,6 +260,193 @@ const EditProfileModal = ({ visible, onClose, onSave, editForm, setEditForm }: E
   </Modal>
 );
 
+// Edit Listing Modal Component
+const EditListingModal = ({ visible, onDismiss, property, onSave }) => {
+  const [editForm, setEditForm] = useState({
+    type: '',
+    bedrooms: '',
+    bathrooms: '',
+    area: '',
+    street_address: '',
+    apt_number: '',
+    city: '',
+    state: '',
+    zip_code: ''
+  });
+
+  // Update form when property changes
+  useEffect(() => {
+    if (property) {
+      setEditForm({
+        type: property.type?.toString() || '',
+        bedrooms: property.bedrooms?.toString() || '',
+        bathrooms: property.bathrooms?.toString() || '',
+        area: property.area?.toString() || '',
+        street_address: property.address?.street_address || '',
+        apt_number: property.apt_number?.toString() || '',
+        city: property.address?.city || '',
+        state: property.address?.state || '',
+        zip_code: property.address?.zip_code || ''
+      });
+    }
+  }, [property]);
+
+  const handleSave = async () => {
+    try {
+      const propertyRef = doc(firestore, "properties", property.id);
+      await updateDoc(propertyRef, {
+        type: editForm.type,
+        bedrooms: Number(editForm.bedrooms),
+        bathrooms: Number(editForm.bathrooms),
+        area: Number(editForm.area),
+        apt_number: editForm.apt_number,
+        address: {
+          street_address: editForm.street_address,
+          city: editForm.city,
+          state: editForm.state,
+          zip_code: editForm.zip_code
+        }
+      });
+      onSave();
+      onDismiss();
+    } catch (error) {
+      console.error("Error updating property:", error);
+      Alert.alert("Error", "Failed to update property. Please try again.");
+    }
+  };
+
+  const inputTheme = {
+    colors: {
+      primary: '#FFD700',
+      background: 'transparent',
+      placeholder: '#666666',
+      text: '#000000',
+    },
+  };
+
+  return (
+    <Modal visible={visible} onDismiss={onDismiss} contentContainerStyle={styles.modalContainer}>
+      <View style={styles.modalStatusBarSpace} />
+      <Card style={styles.modalCard}>
+        <Card.Title 
+          title="Edit Property" 
+          titleStyle={styles.modalTitle}
+          style={styles.modalTitleContainer}
+        />
+        <Card.Content style={styles.modalContent}>
+          <ScrollView showsVerticalScrollIndicator={false}>
+            <View style={styles.formSection}>
+              <Text style={styles.sectionTitle}>Property Details</Text>
+              <TextInput
+                label="Property Type"
+                value={editForm.type}
+                onChangeText={(text) => setEditForm(prev => ({ ...prev, type: text }))}
+                style={styles.input}
+                theme={inputTheme}
+                mode="outlined"
+              />
+              <View style={styles.rowInputs}>
+                <TextInput
+                  label="Bedrooms"
+                  value={editForm.bedrooms}
+                  onChangeText={(text) => setEditForm(prev => ({ ...prev, bedrooms: text }))}
+                  style={[styles.input, styles.halfInput]}
+                  keyboardType="numeric"
+                  theme={inputTheme}
+                  mode="outlined"
+                />
+                <TextInput
+                  label="Bathrooms"
+                  value={editForm.bathrooms}
+                  onChangeText={(text) => setEditForm(prev => ({ ...prev, bathrooms: text }))}
+                  style={[styles.input, styles.halfInput]}
+                  keyboardType="numeric"
+                  theme={inputTheme}
+                  mode="outlined"
+                />
+              </View>
+              <TextInput
+                label="Area (sq ft)"
+                value={editForm.area}
+                onChangeText={(text) => setEditForm(prev => ({ ...prev, area: text }))}
+                style={styles.input}
+                keyboardType="numeric"
+                theme={inputTheme}
+                mode="outlined"
+              />
+            </View>
+
+            <View style={styles.formSection}>
+              <Text style={styles.sectionTitle}>Address Information</Text>
+              <TextInput
+                label="Street Address"
+                value={editForm.street_address}
+                onChangeText={(text) => setEditForm(prev => ({ ...prev, street_address: text }))}
+                style={styles.input}
+                theme={inputTheme}
+                mode="outlined"
+              />
+              <TextInput
+                label="Apartment Number"
+                value={editForm.apt_number}
+                onChangeText={(text) => setEditForm(prev => ({ ...prev, apt_number: text }))}
+                style={styles.input}
+                theme={inputTheme}
+                mode="outlined"
+              />
+              <View style={styles.rowInputs}>
+                <TextInput
+                  label="City"
+                  value={editForm.city}
+                  onChangeText={(text) => setEditForm(prev => ({ ...prev, city: text }))}
+                  style={[styles.input, styles.halfInput]}
+                  theme={inputTheme}
+                  mode="outlined"
+                />
+                <TextInput
+                  label="State"
+                  value={editForm.state}
+                  onChangeText={(text) => setEditForm(prev => ({ ...prev, state: text }))}
+                  style={[styles.input, styles.halfInput]}
+                  theme={inputTheme}
+                  mode="outlined"
+                />
+              </View>
+              <TextInput
+                label="ZIP Code"
+                value={editForm.zip_code}
+                onChangeText={(text) => setEditForm(prev => ({ ...prev, zip_code: text }))}
+                style={styles.input}
+                keyboardType="numeric"
+                theme={inputTheme}
+                mode="outlined"
+              />
+            </View>
+          </ScrollView>
+        </Card.Content>
+        <Card.Actions style={styles.modalActions}>
+          <Button 
+            onPress={onDismiss}
+            mode="outlined"
+            textColor="#000000"
+            style={styles.modalButton}
+          >
+            Cancel
+          </Button>
+          <Button 
+            onPress={handleSave}
+            mode="contained"
+            style={[styles.modalButton, styles.saveButton]}
+            textColor="#000000"
+          >
+            Save Changes
+          </Button>
+        </Card.Actions>
+      </Card>
+    </Modal>
+  );
+};
+
 // Property Card Component
 const PropertyCard = ({ property, onEdit, onDelete }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -390,6 +577,7 @@ export function ProfilePage() {
   });
   const [userProperties, setUserProperties] = useState([]);
   const [isLoadingProperties, setIsLoadingProperties] = useState(false);
+  const [editingProperty, setEditingProperty] = useState(null);
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -495,7 +683,43 @@ export function ProfilePage() {
   };
 
   const handleEditProperty = (property) => {
-    navigation.navigate("EditListing", { listingId: property.id });
+    setEditingProperty(property);
+  };
+
+  const handleSaveProperty = async () => {
+    // Refresh the properties list after saving
+    const fetchUserProperties = async () => {
+      if (!user) return;
+      
+      setIsLoadingProperties(true);
+      try {
+        // Get user's listing IDs
+        const userDocRef = doc(firestore, "users", user.uid);
+        const userDoc = await getDoc(userDocRef);
+        const listingIds = userDoc.data()?.listing_ids || [];
+        
+        // Fetch each property
+        const properties = [];
+        for (const id of listingIds) {
+          const propertyRef = doc(firestore, "properties", id);
+          const propertyDoc = await getDoc(propertyRef);
+          if (propertyDoc.exists()) {
+            properties.push({
+              id: propertyDoc.id,
+              ...propertyDoc.data()
+            });
+          }
+        }
+        
+        setUserProperties(properties);
+      } catch (error) {
+        console.error("Error fetching properties:", error);
+        Alert.alert("Error", "Failed to fetch your properties. Please try again later.");
+      } finally {
+        setIsLoadingProperties(false);
+      }
+    };
+    fetchUserProperties();
   };
 
   const handleDeleteProperty = async (propertyId) => {
@@ -717,6 +941,12 @@ export function ProfilePage() {
         onSave={handleSave}
         editForm={editForm}
         setEditForm={setEditForm}
+      />
+      <EditListingModal
+        visible={editingProperty !== null}
+        onDismiss={() => setEditingProperty(null)}
+        property={editingProperty}
+        onSave={handleSaveProperty}
       />
     </ScrollView>
   );
@@ -961,5 +1191,68 @@ const styles = StyleSheet.create({
   },
   propertyMetricText: {
     fontSize: 13,
+  },
+  modalContainer: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    padding: 20,
+    marginTop: 20,
+  },
+  modalStatusBarSpace: {
+    height: 40,
+  },
+  modalCard: {
+    width: '100%',
+    maxHeight: '90%',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 15,
+  },
+  modalTitleContainer: {
+    backgroundColor: '#FFD700',
+    borderTopLeftRadius: 15,
+    borderTopRightRadius: 15,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#000000',
+  },
+  modalContent: {
+    padding: 15,
+  },
+  formSection: {
+    marginBottom: 20,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 10,
+    color: '#000000',
+  },
+  input: {
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  rowInputs: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 10,
+  },
+  halfInput: {
+    flex: 1,
+  },
+  modalActions: {
+    padding: 15,
+    justifyContent: 'flex-end',
+    borderTopWidth: 1,
+    borderTopColor: '#EEEEEE',
+  },
+  modalButton: {
+    marginLeft: 10,
+    borderColor: '#FFD700',
+  },
+  saveButton: {
+    backgroundColor: '#FFD700',
   },
 });

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -567,9 +567,49 @@ const PropertyCard = ({ property, onEdit, onDelete }) => {
 };
 
 // Saved Property Card Component
-const SavedPropertyCard = ({ property }) => {
+const SavedPropertyCard = ({ property, onRemove }) => {
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
+  const handleRemove = () => {
+    setShowConfirmation(true);
+  };
+
   return (
     <Card style={styles.propertyCard}>
+      <Portal>
+        <Dialog 
+          visible={showConfirmation} 
+          onDismiss={() => setShowConfirmation(false)}
+          style={styles.dialog}
+        >
+          <Dialog.Title style={styles.dialogTitle}>Remove Listing</Dialog.Title>
+          <Dialog.Content>
+            <Paragraph style={styles.dialogContent}>Are you sure you want to remove this listing?</Paragraph>
+          </Dialog.Content>
+          <Dialog.Actions style={styles.dialogActions}>
+            <Button 
+              onPress={() => setShowConfirmation(false)}
+              textColor={theme.colors.text}
+              style={styles.dialogButton}
+            >
+              Cancel
+            </Button>
+            <Button 
+              onPress={() => {
+                setShowConfirmation(false);
+                onRemove(property.id);
+              }}
+              mode="contained"
+              buttonColor={theme.colors.primary}
+              textColor={theme.colors.text}
+              style={styles.dialogButton}
+            >
+              Remove
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+
       <View style={styles.propertyImageWrapper}>
         {property.image_url ? (
           <Image 
@@ -582,6 +622,12 @@ const SavedPropertyCard = ({ property }) => {
             <MaterialCommunityIcons name="image-off" size={40} color="#666" />
           </View>
         )}
+        <TouchableOpacity 
+          style={styles.favoriteButton}
+          onPress={handleRemove}
+        >
+          <MaterialCommunityIcons name="heart" size={24} color={theme.colors.primary} />
+        </TouchableOpacity>
       </View>
 
       <Card.Content style={styles.propertyContent}>
@@ -936,7 +982,7 @@ export function ProfilePage() {
                   </View>
                 ) : (
                   favoritedListings.map((listing) => (
-                    <SavedPropertyCard key={listing.id} property={listing} />
+                    <SavedPropertyCard key={listing.id} property={listing} onRemove={handleRemoveFavorite} />
                   ))
                 )}
               </Card.Content>
@@ -1340,5 +1386,44 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginTop: 4,
+  },
+  favoriteButton: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 8,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+  },
+  dialog: {
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 8,
+  },
+  dialogTitle: {
+    color: theme.colors.text,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  dialogContent: {
+    color: theme.colors.text,
+    textAlign: 'center',
+  },
+  dialogActions: {
+    justifyContent: 'space-around',
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  dialogButton: {
+    minWidth: 100,
   },
 });

--- a/Homelette/components/ProfilePage.tsx
+++ b/Homelette/components/ProfilePage.tsx
@@ -15,27 +15,33 @@ import { useNavigation } from "@react-navigation/native";
 // Mock data for favorited listings
 const mockFavoritedListings = [
   {
-    id: "1",
-    address: "123 Main St",
-    rent: 1200,
-    startDate: "2023-09-04",
-    endDate: "2024-08-31",
-    image: "https://via.placeholder.com/150",
-    bedCount: 3,
-    bathCount: 2,
-    area: 900,
+    id: '1',
+    type: 'Studio Apartment',
+    address: {
+      street_address: '2650 Durant Avenue',
+      city: 'Berkeley',
+      state: 'CA',
+      zip_code: '94704'
+    },
+    bedrooms: 0,
+    bathrooms: 1,
+    area: 450,
+    image_url: null
   },
   {
-    id: "2",
-    address: "456 Elm St",
-    rent: 1500,
-    startDate: "2023-10-01",
-    endDate: "2024-09-30",
-    image: "https://via.placeholder.com/150",
-    bedCount: 4,
-    bathCount: 3,
-    area: 1400,
-  },
+    id: '2',
+    type: '2 Bedroom Apartment',
+    address: {
+      street_address: '2728 Dwight Way',
+      city: 'Berkeley',
+      state: 'CA',
+      zip_code: '94704'
+    },
+    bedrooms: 2,
+    bathrooms: 1,
+    area: 750,
+    image_url: null
+  }
 ];
 
 // Color theme matching RentPage.tsx
@@ -560,6 +566,57 @@ const PropertyCard = ({ property, onEdit, onDelete }) => {
   );
 };
 
+// Saved Property Card Component
+const SavedPropertyCard = ({ property }) => {
+  return (
+    <Card style={styles.propertyCard}>
+      <View style={styles.propertyImageWrapper}>
+        {property.image_url ? (
+          <Image 
+            source={{ uri: property.image_url }} 
+            style={styles.propertyImage}
+            resizeMode="cover"
+          />
+        ) : (
+          <View style={[styles.propertyImage, styles.propertyImagePlaceholder]}>
+            <MaterialCommunityIcons name="image-off" size={40} color="#666" />
+          </View>
+        )}
+      </View>
+
+      <Card.Content style={styles.propertyContent}>
+        <View style={styles.propertyHeader}>
+          <View>
+            <Title style={styles.propertyType}>{property.type}</Title>
+            <Paragraph style={styles.propertyAddress} numberOfLines={2}>
+              {property.address.street_address}, {property.address.city}, {property.address.state} {property.address.zip_code}
+            </Paragraph>
+          </View>
+        </View>
+
+        <View style={styles.propertyStats}>
+          <View style={styles.propertyStat}>
+            <MaterialCommunityIcons name="bed" size={20} color="#666" />
+            <Text style={styles.propertyStatText}>
+              {property.bedrooms === 0 ? 'Studio' : property.bedrooms}
+            </Text>
+          </View>
+          <View style={styles.propertyStatDivider} />
+          <View style={styles.propertyStat}>
+            <MaterialCommunityIcons name="shower" size={20} color="#666" />
+            <Text style={styles.propertyStatText}>{property.bathrooms}</Text>
+          </View>
+          <View style={styles.propertyStatDivider} />
+          <View style={styles.propertyStat}>
+            <MaterialCommunityIcons name="ruler-square" size={20} color="#666" />
+            <Text style={styles.propertyStatText}>{property.area} ft²</Text>
+          </View>
+        </View>
+      </Card.Content>
+    </Card>
+  );
+};
+
 export function ProfilePage() {
   const { user } = useAuth();
   const navigation = useNavigation();
@@ -879,11 +936,7 @@ export function ProfilePage() {
                   </View>
                 ) : (
                   favoritedListings.map((listing) => (
-                    <FavoritedListingCard 
-                      key={listing.id} 
-                      item={listing} 
-                      onRemoveFavorite={handleRemoveFavorite} 
-                    />
+                    <SavedPropertyCard key={listing.id} property={listing} />
                   ))
                 )}
               </Card.Content>
@@ -1259,5 +1312,33 @@ const styles = StyleSheet.create({
   },
   saveButton: {
     backgroundColor: '#FFD700',
+  },
+  propertyAddress: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
+  },
+  propertyStats: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    marginTop: 16,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(0,0,0,0.1)',
+  },
+  propertyStat: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  propertyStatDivider: {
+    width: 1,
+    height: 24,
+    backgroundColor: 'rgba(0,0,0,0.1)',
+  },
+  propertyStatText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginTop: 4,
   },
 });


### PR DESCRIPTION
User can now see their saved listings (frontend only) and their owned listings (frontend and backend) from their profile. Saved listings has an unfavorite option with a confirmation popup and shows basic information about the property. My listings has a functional edit listing feature and trash listing feature (with a confirmation popup) and shows basic information about the property as well as favorites and chats (frontend only). 

Closes #47, #89, #90

![image](https://github.com/user-attachments/assets/e36378fd-9fb9-4346-bf96-70cc4b9ec7cc)
![image](https://github.com/user-attachments/assets/c28bbac2-c7b8-48cd-8de6-8c903ca01220)
![image](https://github.com/user-attachments/assets/9f827aa9-bb92-4744-ba89-96e6ddb49273)
![image](https://github.com/user-attachments/assets/d82a7a96-aa8a-414d-89b5-e825463df972)
![image](https://github.com/user-attachments/assets/ebc0eb13-6e83-4eeb-b0e1-2ea3968ecc23)
![image](https://github.com/user-attachments/assets/9cc0951b-6300-41e0-9939-2cac9f875965)